### PR TITLE
Analyse same commit as other code scanning tools

### DIFF
--- a/.github/workflows/ossar-analysis.yml
+++ b/.github/workflows/ossar-analysis.yml
@@ -17,15 +17,6 @@ jobs:
       # Checkout your code repository to scan
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Ensure a compatible version of dotnet is installed.
     # The [Microsoft Security Code Analysis CLI](https://aka.ms/mscadocs) is built with dotnet v3.1.201.


### PR DESCRIPTION
Hello! I am from the code scanning team!

We noticed that sometimes your analyses are going missing, e.g: https://github.com/EnMarche/Coalitions/pull/197/checks?check_run_id=2202388803

This is because OSSAR and CodeQL are currently configured to analyse different commits.

This PR should resolve your issue. :heart: